### PR TITLE
Attempt to synthesize a code section if non are available in order to suport ngen-generated PDBs

### DIFF
--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -107,6 +107,19 @@ impl<'s> DebugInformation<'s> {
         let contributions_buf = buf.take(self.header.section_contribution_size as usize)?;
         DBISectionContributionIter::parse(contributions_buf.into())
     }
+
+    /// Returns an iterator that can traverse the section map in sequential order. Also known as the "OMF Segment map".
+    pub fn section_map(&self) -> Result<DBISectionMapIter<'_>> {
+        let mut buf = self.stream.parse_buffer();
+        // drop the header, modules list, and section contributions list
+        let offset = self.header_len +
+            self.header.module_list_size as usize +
+            self.header.section_contribution_size as usize;
+
+        buf.take(offset)?;
+        let section_map_buf = buf.take(self.header.section_map_size as usize)?;
+        DBISectionMapIter::parse(section_map_buf.into())
+    }
 }
 
 /// The version of the PDB format.
@@ -581,6 +594,64 @@ impl<'c> FallibleIterator for DBISectionContributionIter<'c> {
             self.buf.parse_u32()?;
         }
         Ok(Some(contribution))
+    }
+}
+
+/// See https://github.com/google/syzygy/blob/8164b24ebde9c5649c9a09e88a7fc0b0fcbd1bc5/syzygy/pdb/pdb_data.h#L172
+#[derive(Debug, Copy, Clone)]
+pub struct DBISectionMapItem {
+    pub flags: u8,
+    pub section_type: u8,
+    pub unknown_data_1: u32,
+    pub section_number: u16,
+    pub unknown_data_2: u32, // technically OMFSegMapDesc seg_name_index: u16, class_name_index: u16
+    pub rva_offset: u32,
+    pub section_length: u32,
+}
+
+impl DBISectionMapItem {
+    fn parse(buf: &mut ParseBuffer<'_>) -> Result<Self> {
+        Ok(Self {
+            flags: buf.parse_u8()?,
+            section_type: buf.parse_u8()?,
+            unknown_data_1: buf.parse_u32()?,
+            section_number: buf.parse_u16()?,
+            unknown_data_2: buf.parse_u32()?,
+            rva_offset: buf.parse_u32()?,
+            section_length: buf.parse_u32()?,
+        })
+    }
+}
+
+/// A `DBISectionMapIter` iterates over the section map in the DBI section, producing `DBISectionMap`s.
+#[derive(Debug)]
+pub struct DBISectionMapIter<'c> {
+    buf: ParseBuffer<'c>,
+}
+
+impl<'c> DBISectionMapIter<'c> {
+    fn parse(mut buf: ParseBuffer<'c>) -> Result<Self> {
+        let sec_count = buf.parse_u16()?;
+        let sec_count_log = buf.parse_u16()?;
+
+        println!("sec_count: {}, sec_count_log: {}", sec_count, sec_count_log);
+
+        Ok(Self { buf })
+    }
+}
+
+impl<'c> FallibleIterator for DBISectionMapIter<'c> {
+    type Item = DBISectionMapItem;
+    type Error = Error;
+
+    fn next(&mut self) -> result::Result<Option<Self::Item>, Self::Error> {
+        // see if we're at EOF
+        if self.buf.is_empty() {
+            return Ok(None);
+        }
+
+        let segmap = Self::Item::parse(&mut self.buf)?;
+        Ok(Some(segmap))
     }
 }
 

--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -634,8 +634,6 @@ impl<'c> DBISectionMapIter<'c> {
         let sec_count = buf.parse_u16()?;
         let sec_count_log = buf.parse_u16()?;
 
-        println!("sec_count: {}, sec_count_log: {}", sec_count, sec_count_log);
-
         Ok(Self { buf })
     }
 }

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -286,11 +286,6 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
             sec_contribs.iter().any(|sc| sc.characteristics.executable() && sc.offset.section == p.section_number)
         }).collect::<Vec<_>>();
 
-        println!("{} items", sec_map.len());
-        for &sc in sec_map.iter() {
-            println!("{:?}", sc);
-        }
-
         if sec_map.len() != 1 {
             eprintln!("Multiple or zero sections in map with executable contributions found, can't synthesize a section");
             return Ok(None);
@@ -298,7 +293,6 @@ impl<'s, S: Source<'s> + 's> PDB<'s, S> {
 
         let sm = sec_map[0];
         const DEFAULT_RVA: u32 = 0x1000; // In the absence of section data and OMAP From, this is 0x1000
-        eprintln!("Synthesized section");
         Ok(Some(vec![
             ImageSectionHeader {
                 name: [0; 8],


### PR DESCRIPTION
Based on suggestions I got in https://github.com/getsentry/pdb/issues/153 -- this PR attempts to synthesize a section if:

1. There is no section data
2. There is no OMAP From data
3. There is only one entry in the section map that has any executable ranges from the section contributions

I have no idea how correct this is, but it seems to work in my (currently limited) sample size. I can at least compare my resolution with Microsoft's for stack traces so I'll keep checking. 

Without this, for these PDBs it's possible to get a list of the global symbols, but no address map translator can be created meaning that in practice it's not possible to do anything with those symbols.

Background here, from that linked issue:

I'm working to improve some profiling tools (`samply` specifically) that uses the `pdb` create under the hood. Part of what I need is being able to handle symbols for .NET, specifically symbols from Crossgen2-built Ready 2 Run assemblies. I think that's where things are coming from anyway, anyway -- things that end in .ni.pdb, I think written here with some comments about DiaSymReader and other: https://github.com/dotnet/runtime/blob/fc76b1cac3f02cc9729f6682d6850fd7982e9fe5/src/coreclr/tools/aot/ILCompiler.Diagnostics/PdbWriter.cs#L199

Here's an example of this type of PDB, from Microsoft's symbol server: [dotnet.ni.dll](https://msdl.microsoft.com/download/symbols/dotnet.ni.pdb/EE180EE3BC55A7F51FD760F808D65B301/dotnet.ni.pdb) Also just in case, this isn't a Portable PDB, it's a normal PDB, but I think written in a very limited way. It's just the symbol information.

When read by the `pdb` create, these pdbs show up as having no section information. Which means it can't get an address map, which means that I end up with no way of translating RVA addresses to symbols. Section contribution information is there though, e.g. here's `dia2dump -x`:

```
*** SECTION CONTRIBUTION

    RVA        Address       Size    Module
  00001000  0001:00000000  00275000  C:\Users\cloudtest\AppData\Local\Temp\5egk1fj3.cpa\dotnet.dll
  00276000  0002:00000000  00034000  C:\Users\cloudtest\AppData\Local\Temp\5egk1fj3.cpa\dotnet.dll
  002AA000  0003:00000000  00004000  C:\Users\cloudtest\AppData\Local\Temp\5egk1fj3.cpa\dotnet.dll
```

These section contributions map directly to the 3 sections in the actual code `dotnet.dll`. I have no idea where `dia2dump` is getting the `RVA` from above (especially the ones beyond the first section), as it's not in the section contrib information. I do see in `PdbWriter.cs` some places where sections are written, but I have no idea where that info is going!

If I parse it the section_map as a [DbiSectionMap from syzygy](https://github.com/google/syzygy/blob/8164b24ebde9c5649c9a09e88a7fc0b0fcbd1bc5/syzygy/pdb/pdb_data.h#L172) I get:
```
DBISectionMapItem { flags: 13, section_type: 1, unknown_data_1: 0, section_number: 1, unknown_data_2: 4294967295, rva_offset: 0, section_length: 2576384 }
DBISectionMapItem { flags: 13, section_type: 1, unknown_data_1: 0, section_number: 2, unknown_data_2: 4294967295, rva_offset: 0, section_length: 212992 }
DBISectionMapItem { flags: 13, section_type: 1, unknown_data_1: 0, section_number: 3, unknown_data_2: 4294967295, rva_offset: 0, section_length: 16384 }
DBISectionMapItem { flags: 8, section_type: 2, unknown_data_1: 0, section_number: 0, unknown_data_2: 4294967295, rva_offset: 0, section_length: 4294967295 }
```

