### PR TITLE
Fix incorrect parsing of LF_FIELDLIST continuation record

### DIFF
--- a/src/tpi/data.rs
+++ b/src/tpi/data.rs
@@ -419,7 +419,10 @@ pub(crate) fn parse_type_data<'t>(buf: &mut ParseBuffer<'t>) -> Result<TypeData<
                 match buf.peek_u16()? {
                     LF_INDEX => {
                         // continuation record
-                        // eat the leaf value
+                        // eat the leaf value, which we just peeked at
+                        buf.parse_u16()?;
+
+                        // eat another u16, which is padding (always 0 in files produced by MSVC)
                         buf.parse_u16()?;
 
                         // parse the TypeIndex where we continue


### PR DESCRIPTION
The continuation contains an internal u16 padding value, which we need to skip in order to get correct data afterward.

[Microsoft's description of the structure](https://github.com/microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L2485)

Most people should never encounter this problem, since a class, struct or enum needs to have over 2000 members resulting in a 64 kB field list before a continuation is generated.