### PR TITLE
Vector35 enhancements part 1

### DIFF
--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -236,6 +236,12 @@ pub enum SymbolData<'t> {
     Section(SectionSymbol<'t>),
     /// A COFF group.
     CoffGroup(CoffGroupSymbol<'t>),
+    /// A live range of a variable.
+    DefRange(DefRangeSymbol),
+    /// A live range of a sub field of a variable.
+    DefRangeSubField(DefRangeSubFieldSymbol),
+    /// A live range of a register variable.
+    DefRangeRegister(DefRangeRegisterSymbol),
 }
 
 impl<'t> SymbolData<'t> {
@@ -276,6 +282,9 @@ impl<'t> SymbolData<'t> {
             Self::EnvBlock(_) => None,
             Self::Section(data) => Some(data.name),
             Self::CoffGroup(data) => Some(data.name),
+            Self::DefRange(_) => None,
+            Self::DefRangeSubField(_) => None,
+            Self::DefRangeRegister(_) => None,
         }
     }
 }
@@ -336,6 +345,9 @@ impl<'t> TryFromCtx<'t> for SymbolData<'t> {
             S_ENVBLOCK => SymbolData::EnvBlock(buf.parse_with(kind)?),
             S_SECTION => SymbolData::Section(buf.parse_with(kind)?),
             S_COFFGROUP => SymbolData::CoffGroup(buf.parse_with(kind)?),
+            S_DEFRANGE => SymbolData::DefRange(buf.parse_with(kind)?),
+            S_DEFRANGE_SUBFIELD => SymbolData::DefRangeSubField(buf.parse_with(kind)?),
+            S_DEFRANGE_REGISTER => SymbolData::DefRangeRegister(buf.parse_with(kind)?),
             other => return Err(Error::UnimplementedSymbolKind(other)),
         };
 
@@ -1348,6 +1360,198 @@ impl<'t> TryFromCtx<'t, SymbolKind> for ManagedSlotSymbol<'t> {
             flags: buf.parse()?,
             name: parse_symbol_name(&mut buf, kind)?,
         };
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L3102
+/// An address range of a live range.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AddressRange {
+    /// Offset of the range.
+    pub offset: PdbInternalSectionOffset,
+    /// Length of the range.
+    pub cb_range: u16,
+}
+
+impl<'t> TryFromCtx<'t, Endian> for AddressRange {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'t [u8], _le: Endian) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        let range = Self {
+            offset: buf.parse()?,
+            cb_range: buf.parse()?,
+        };
+
+        Ok((range, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L3111
+/// A gap in a live range.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AddressGap {
+    /// Relative offset from the beginning of the live range
+    pub gap_start_offset: u16,
+    /// Length of the gap
+    pub cb_range: u16,
+}
+
+impl<'t> TryFromCtx<'t, Endian> for AddressGap {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'t [u8], _: Endian) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        let range = Self {
+            gap_start_offset: buf.parse()?,
+            cb_range: buf.parse()?,
+        };
+
+        Ok((range, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4209
+/// A live range of sub field of variable
+///
+/// Symbol kind `S_DEFRANGE`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DefRangeSymbol {
+    /// DIA program to evaluate the value of the symbol
+    pub program: u32,
+    /// Range of addresses where this program is valid
+    pub range: AddressRange,
+    /// The value is not available in following gaps
+    pub gaps: Vec<AddressGap>,
+}
+
+impl TryFromCtx<'_, SymbolKind> for DefRangeSymbol {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'_ [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4313
+        let gap_count = (
+            buf.len() + 4 /* sizeof(reclen) + buf offset */
+            - 16 /* sizeof(DEFRANGESYM) */
+        ) / 4 /* sizeof(CV_LVAR_ADDR_GAP) */;
+        let mut symbol = Self {
+            program: buf.parse()?,
+            range: buf.parse()?,
+            gaps: vec![],
+        };
+        for _ in 0..gap_count {
+            symbol.gaps.push(buf.parse()?);
+        }
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L3102
+/// A live range of sub field of variable. like locala.i
+///
+/// Symbol kind `S_DEFRANGE_SUBFIELD`
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DefRangeSubFieldSymbol {
+    /// DIA program to evaluate the value of the symbol
+    pub program: u32,
+    /// Offset in parent variable.
+    pub parent_offset: u32,
+    /// Range of addresses where this program is valid
+    pub range: AddressRange,
+    /// The value is not available in following gaps
+    pub gaps: Vec<AddressGap>,
+}
+
+impl TryFromCtx<'_, SymbolKind> for DefRangeSubFieldSymbol {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'_ [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4313
+        let gap_count = (
+            buf.len() + 4 /* sizeof(reclen) + buf offset */
+            - 20 /* sizeof(DEFRANGESYMSUBFIELD) */
+        ) / 4 /* sizeof(CV_LVAR_ADDR_GAP) */;
+        let mut symbol = Self {
+            program: buf.parse()?,
+            parent_offset: buf.parse()?,
+            range: buf.parse()?,
+            gaps: vec![],
+        };
+        for _ in 0..gap_count {
+            symbol.gaps.push(buf.parse()?);
+        }
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4231
+/// Flags of a [`DefRangeRegisterSymbol`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RangeFlags {
+    /// May have no user name on one of control flow path.
+    pub maybe: bool,
+}
+
+impl<'t> TryFromCtx<'t, Endian> for RangeFlags {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> std::result::Result<(Self, usize), Self::Error> {
+        let (value, size) = u16::try_from_ctx(this, le)?;
+
+        let flags = Self {
+            maybe: value & 0x01 != 0,
+        };
+
+        Ok((flags, size))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4236
+/// A live range of en-registed variable
+///
+/// Symbol type `S_DEFRANGE_REGISTER`
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DefRangeRegisterSymbol {
+    /// Register to hold the value of the symbol
+    pub register: u16,
+    /// Attribute of the register range.
+    pub flags: RangeFlags,
+    /// Range of addresses where this program is valid
+    pub range: AddressRange,
+    /// The value is not available in following gaps
+    pub gaps: Vec<AddressGap>,
+}
+
+impl TryFromCtx<'_, SymbolKind> for DefRangeRegisterSymbol {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'_ [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4313
+        let gap_count = (
+            buf.len() + 4 /* sizeof(reclen) + buf offset */
+            - 16 /* sizeof(DEFRANGESYM) */
+        ) / 4 /* sizeof(CV_LVAR_ADDR_GAP) */;
+        let mut symbol = Self {
+            register: buf.parse()?,
+            flags: buf.parse()?,
+            range: buf.parse()?,
+            gaps: vec![],
+        };
+        for _ in 0..gap_count {
+            symbol.gaps.push(buf.parse()?);
+        }
 
         Ok((symbol, buf.pos()))
     }
@@ -2644,6 +2848,58 @@ mod tests {
             };
             assert_eq!(symbol.raw_kind(), 0x114e);
             assert_eq!(symbol.parse().expect("parse"), SymbolData::InlineSiteEnd);
+        }
+
+        #[test]
+        fn kind_1141() {
+            let data = &[65, 17, 17, 0, 0, 0, 70, 40, 0, 0, 1, 0, 66, 0, 44, 0, 19, 0];
+
+            let symbol = Symbol {
+                data,
+                index: SymbolIndex(0),
+            };
+            assert_eq!(symbol.raw_kind(), 0x1141);
+            assert_eq!(
+                symbol.parse().expect("parse"),
+                SymbolData::DefRangeRegister(DefRangeRegisterSymbol {
+                    register: 17,
+                    flags: RangeFlags { maybe: false },
+                    range: AddressRange {
+                        offset: PdbInternalSectionOffset {
+                            offset: 0x2846,
+                            section: 1,
+                        },
+                        cb_range: 0x42,
+                    },
+                    gaps: vec![AddressGap {
+                        gap_start_offset: 0x2c,
+                        cb_range: 0x13
+                    }]
+                })
+            );
+
+            let data = &[65, 17, 19, 0, 1, 0, 156, 41, 0, 0, 1, 0, 2, 0];
+
+            let symbol = Symbol {
+                data,
+                index: SymbolIndex(0),
+            };
+            assert_eq!(symbol.raw_kind(), 0x1141);
+            assert_eq!(
+                symbol.parse().expect("parse"),
+                SymbolData::DefRangeRegister(DefRangeRegisterSymbol {
+                    register: 0x13,
+                    flags: RangeFlags { maybe: true },
+                    range: AddressRange {
+                        offset: PdbInternalSectionOffset {
+                            offset: 0x299c,
+                            section: 1,
+                        },
+                        cb_range: 2,
+                    },
+                    gaps: vec![]
+                })
+            );
         }
     }
 

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -242,6 +242,14 @@ pub enum SymbolData<'t> {
     DefRangeSubField(DefRangeSubFieldSymbol),
     /// A live range of a register variable.
     DefRangeRegister(DefRangeRegisterSymbol),
+    /// A live range of a frame pointer-relative variable.
+    DefRangeFramePointerRelative(DefRangeFramePointerRelativeSymbol),
+    /// A frame-pointer variable which is valid in the full scope of the function.
+    DefRangeFramePointerRelativeFullScope(DefRangeFramePointerRelativeFullScopeSymbol),
+    /// A live range of a sub field of a register variable.
+    DefRangeSubFieldRegister(DefRangeSubFieldRegisterSymbol),
+    /// A live range of a variable related to a register.
+    DefRangeRegisterRelative(DefRangeRegisterRelativeSymbol),
 }
 
 impl<'t> SymbolData<'t> {
@@ -285,6 +293,10 @@ impl<'t> SymbolData<'t> {
             Self::DefRange(_) => None,
             Self::DefRangeSubField(_) => None,
             Self::DefRangeRegister(_) => None,
+            Self::DefRangeFramePointerRelative(_) => None,
+            Self::DefRangeFramePointerRelativeFullScope(_) => None,
+            Self::DefRangeSubFieldRegister(_) => None,
+            Self::DefRangeRegisterRelative(_) => None,
         }
     }
 }
@@ -348,6 +360,16 @@ impl<'t> TryFromCtx<'t> for SymbolData<'t> {
             S_DEFRANGE => SymbolData::DefRange(buf.parse_with(kind)?),
             S_DEFRANGE_SUBFIELD => SymbolData::DefRangeSubField(buf.parse_with(kind)?),
             S_DEFRANGE_REGISTER => SymbolData::DefRangeRegister(buf.parse_with(kind)?),
+            S_DEFRANGE_FRAMEPOINTER_REL => {
+                SymbolData::DefRangeFramePointerRelative(buf.parse_with(kind)?)
+            }
+            S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE => {
+                SymbolData::DefRangeFramePointerRelativeFullScope(buf.parse_with(kind)?)
+            }
+            S_DEFRANGE_SUBFIELD_REGISTER => {
+                SymbolData::DefRangeSubFieldRegister(buf.parse_with(kind)?)
+            }
+            S_DEFRANGE_REGISTER_REL => SymbolData::DefRangeRegisterRelative(buf.parse_with(kind)?),
             other => return Err(Error::UnimplementedSymbolKind(other)),
         };
 
@@ -1546,6 +1568,171 @@ impl TryFromCtx<'_, SymbolKind> for DefRangeRegisterSymbol {
         let mut symbol = Self {
             register: buf.parse()?,
             flags: buf.parse()?,
+            range: buf.parse()?,
+            gaps: vec![],
+        };
+        for _ in 0..gap_count {
+            symbol.gaps.push(buf.parse()?);
+        }
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4245
+/// A live range of frame variable
+///
+/// Symbol type `S_DEFRANGE_FRAMEPOINTER_REL`
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DefRangeFramePointerRelativeSymbol {
+    /// offset to frame pointer
+    pub offset: u32,
+    /// Range of addresses where this program is valid
+    pub range: AddressRange,
+    /// The value is not available in following gaps
+    pub gaps: Vec<AddressGap>,
+}
+
+impl TryFromCtx<'_, SymbolKind> for DefRangeFramePointerRelativeSymbol {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'_ [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4313
+        let gap_count = (
+            buf.len() + 4 /* sizeof(reclen) + buf offset */
+                - 16 /* sizeof(DEFRANGESYM) */
+        ) / 4 /* sizeof(CV_LVAR_ADDR_GAP) */;
+        let mut symbol = Self {
+            offset: buf.parse()?,
+            range: buf.parse()?,
+            gaps: vec![],
+        };
+        for _ in 0..gap_count {
+            symbol.gaps.push(buf.parse()?);
+        }
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4255
+/// A frame variable valid in all function scope
+///
+/// Symbol type `S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE`
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct DefRangeFramePointerRelativeFullScopeSymbol {
+    /// offset to frame pointer
+    pub offset: u32,
+}
+
+impl TryFromCtx<'_, SymbolKind> for DefRangeFramePointerRelativeFullScopeSymbol {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'_ [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        let symbol = Self {
+            offset: buf.parse()?,
+        };
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4264
+/// A live range of sub field of variable. like locala.i
+///
+/// Symbol type `S_DEFRANGE_SUBFIELD_REGISTER`
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DefRangeSubFieldRegisterSymbol {
+    /// Register to hold the value of the symbol
+    pub register: u16,
+    /// Attribute of the register range.
+    pub flags: RangeFlags,
+    /// Offset in parent variable.
+    pub offset: u32,
+    /// Range of addresses where this program is valid
+    pub range: AddressRange,
+    /// The value is not available in following gaps
+    pub gaps: Vec<AddressGap>,
+}
+
+impl TryFromCtx<'_, SymbolKind> for DefRangeSubFieldRegisterSymbol {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'_ [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4313
+        let gap_count = (
+            buf.len() + 4 /* sizeof(reclen) + buf offset */
+                - 20 /* sizeof(DEFRANGESYMSUBFIELD) */
+        ) / 4 /* sizeof(CV_LVAR_ADDR_GAP) */;
+
+        let register: u16 = buf.parse()?;
+        let flags: RangeFlags = buf.parse()?;
+        let offset_padding: u32 = buf.parse()?;
+        let offset = offset_padding & 0xFFFu32;
+
+        let mut symbol = Self {
+            register,
+            flags,
+            offset,
+            range: buf.parse()?,
+            gaps: vec![],
+        };
+        for _ in 0..gap_count {
+            symbol.gaps.push(buf.parse()?);
+        }
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4279
+/// A live range of variable related to a register.
+///
+/// Symbol type `S_DEFRANGE_REGISTER_REL`
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DefRangeRegisterRelativeSymbol {
+    /// Register to hold the base pointer of the symbol
+    pub base_register: u16,
+    /// Spilled member for s.i.
+    pub spilled_udt_member: u16,
+    /// Offset in parent variable.
+    pub offset_parent: u16,
+    /// offset to register
+    pub offset_base_pointer: u32,
+    /// Range of addresses where this program is valid
+    pub range: AddressRange,
+    /// The value is not available in following gaps
+    pub gaps: Vec<AddressGap>,
+}
+
+impl TryFromCtx<'_, SymbolKind> for DefRangeRegisterRelativeSymbol {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'_ [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4313
+        let gap_count = (
+            buf.len() + 4 /* sizeof(reclen) + buf offset */
+                - 20 /* sizeof(DEFRANGESYMSUBFIELD) */
+        ) / 4 /* sizeof(CV_LVAR_ADDR_GAP) */;
+
+        let base_register: u16 = buf.parse()?;
+        let bitfield: u16 = buf.parse()?;
+        let spilled_udt_member = bitfield & 0x1;
+        let offset_parent = (bitfield >> 4) & 0xFFF;
+
+        let mut symbol = Self {
+            base_register,
+            spilled_udt_member,
+            offset_parent,
+            offset_base_pointer: buf.parse()?,
             range: buf.parse()?,
             gaps: vec![],
         };


### PR DESCRIPTION
Here are two more improvements by @CouleeApps from the vector35 repo.
They contain the implementations for the symbol types:
- S_DEFRANGE 
- S_DEFRANGE_SUBFIELD 
- S_DEFRANGE_REGISTER 
- S_DEFRANGE_FRAMEPOINTER_REL 
- S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE 
- S_DEFRANGE_SUBFIELD_REGISTER 
- S_DEFRANGE_REGISTER_REL 

They are almost identical to changes I made myself, but more complete (for example, I only had a u32 value for the flags).

I rebased these onto the current master, and did some tests.
I intend to send you all the rest of the changes from from vector35 once I have done the same there.