### PR TITLE
clippy fixes

### DIFF
--- a/examples/pdb2hpp.rs
+++ b/examples/pdb2hpp.rs
@@ -83,12 +83,12 @@ pub fn type_name(
         pdb::TypeData::Array(data) => {
             let mut name = type_name(type_finder, data.element_type, needed_types)?;
             for size in data.dimensions {
-                name = format!("{}[{}]", name, size);
+                name = format!("{name}[{size}]");
             }
             name
         }
 
-        _ => format!("Type{} /* TODO: figure out how to name it */", type_index),
+        _ => format!("Type{type_index} /* TODO: figure out how to name it */"),
     };
 
     // TODO: search and replace std:: patterns
@@ -139,10 +139,7 @@ impl<'p> Class<'p> {
                 }
             }
             other => {
-                println!(
-                    "trying to Class::add_fields() got {} -> {:?}",
-                    type_index, other
-                );
+                println!("trying to Class::add_fields() got {type_index} -> {other:?}");
                 panic!("unexpected type in Class::add_fields()");
             }
         }
@@ -352,7 +349,7 @@ impl<'p> Method<'p> {
             }),
 
             other => {
-                println!("other: {:?}", other);
+                println!("other: {other:?}");
                 Err(pdb::Error::UnimplementedFeature("that"))
             }
         }
@@ -404,10 +401,7 @@ impl<'p> Enum<'p> {
                 }
             }
             other => {
-                println!(
-                    "trying to Enum::add_fields() got {} -> {:?}",
-                    type_index, other
-                );
+                println!("trying to Enum::add_fields() got {type_index} -> {other:?}");
                 panic!("unexpected type in Enum::add_fields()");
             }
         }
@@ -441,14 +435,14 @@ impl fmt::Display for Enum<'_> {
                 "\t{} = {},",
                 value.name.to_string(),
                 match value.value {
-                    pdb::Variant::U8(v) => format!("0x{:02x}", v),
-                    pdb::Variant::U16(v) => format!("0x{:04x}", v),
-                    pdb::Variant::U32(v) => format!("0x{:08x}", v),
-                    pdb::Variant::U64(v) => format!("0x{:16x}", v),
-                    pdb::Variant::I8(v) => format!("{}", v),
-                    pdb::Variant::I16(v) => format!("{}", v),
-                    pdb::Variant::I32(v) => format!("{}", v),
-                    pdb::Variant::I64(v) => format!("{}", v),
+                    pdb::Variant::U8(v) => format!("0x{v:02x}"),
+                    pdb::Variant::U16(v) => format!("0x{v:04x}"),
+                    pdb::Variant::U32(v) => format!("0x{v:08x}"),
+                    pdb::Variant::U64(v) => format!("0x{v:16x}"),
+                    pdb::Variant::I8(v) => format!("{v}"),
+                    pdb::Variant::I16(v) => format!("{v}"),
+                    pdb::Variant::I32(v) => format!("{v}"),
+                    pdb::Variant::I64(v) => format!("{v}"),
                 }
             )?;
         }
@@ -580,7 +574,7 @@ impl<'p> Data<'p> {
             }
 
             // ignore
-            other => eprintln!("warning: don't know how to add {:?}", other),
+            other => eprintln!("warning: don't know how to add {other:?}"),
         }
 
         Ok(())
@@ -622,16 +616,16 @@ fn write_class(filename: &str, class_name: &str) -> pdb::Result<()> {
     }
 
     if data.classes.is_empty() {
-        eprintln!("sorry, class {} was not found", class_name);
+        eprintln!("sorry, class {class_name} was not found");
     } else {
-        println!("{}", data);
+        println!("{data}");
     }
 
     Ok(())
 }
 
 fn print_usage(program: &str, opts: getopts::Options) {
-    let brief = format!("Usage: {} input.pdb ClassName", program);
+    let brief = format!("Usage: {program} input.pdb ClassName");
     print!("{}", opts.usage(&brief));
 }
 
@@ -656,6 +650,6 @@ fn main() {
 
     match write_class(filename, class_name) {
         Ok(_) => (),
-        Err(e) => eprintln!("error dumping PDB: {}", e),
+        Err(e) => eprintln!("error dumping PDB: {e}"),
     }
 }

--- a/examples/pdb_framedata.rs
+++ b/examples/pdb_framedata.rs
@@ -6,7 +6,7 @@ use getopts::Options;
 use pdb::FallibleIterator;
 
 fn print_usage(program: &str, opts: Options) {
-    let brief = format!("Usage: {} input.pdb", program);
+    let brief = format!("Usage: {program} input.pdb");
     print!("{}", opts.usage(&brief));
 }
 
@@ -69,6 +69,6 @@ fn main() {
 
     match dump_framedata(filename) {
         Ok(_) => (),
-        Err(e) => eprintln!("error dumping PDB: {}", e),
+        Err(e) => eprintln!("error dumping PDB: {e}"),
     }
 }

--- a/examples/pdb_lines.rs
+++ b/examples/pdb_lines.rs
@@ -72,7 +72,7 @@ fn main() {
     match dump_pdb(filename) {
         Ok(_) => {}
         Err(e) => {
-            writeln!(&mut std::io::stderr(), "error dumping PDB: {}", e).expect("stderr write");
+            writeln!(&mut std::io::stderr(), "error dumping PDB: {e}").expect("stderr write");
         }
     }
 }

--- a/examples/pdb_symbols.rs
+++ b/examples/pdb_symbols.rs
@@ -6,7 +6,7 @@ use getopts::Options;
 use pdb::{FallibleIterator, PdbInternalSectionOffset, RawString};
 
 fn print_usage(program: &str, opts: Options) {
-    let brief = format!("Usage: {} input.pdb", program);
+    let brief = format!("Usage: {program} input.pdb");
     print!("{}", opts.usage(&brief));
 }
 
@@ -28,12 +28,10 @@ fn print_symbol(symbol: &pdb::Symbol<'_>) -> pdb::Result<()> {
         pdb::SymbolData::Procedure(data) => {
             print_row(data.offset, "function", data.name);
         }
-        pdb::SymbolData::ManagedProcedure(data) => {
-            match data.name {
-                None => print_row(data.offset, "function", RawString::from(&b"<empty>"[..])),
-                Some(name) => print_row(data.offset, "function", name),
-            }
-        }
+        pdb::SymbolData::ManagedProcedure(data) => match data.name {
+            None => print_row(data.offset, "function", RawString::from(&b"<empty>"[..])),
+            Some(name) => print_row(data.offset, "function", name),
+        },
         pdb::SymbolData::ManagedSlot(data) => {
             print_row(data.offset, "data", data.name);
         }
@@ -51,7 +49,7 @@ fn walk_symbols(mut symbols: pdb::SymbolIter<'_>) -> pdb::Result<()> {
     while let Some(symbol) = symbols.next()? {
         match print_symbol(&symbol) {
             Ok(_) => (),
-            Err(e) => eprintln!("error printing symbol {:?}: {}", symbol, e),
+            Err(e) => eprintln!("error printing symbol {symbol:?}: {e}"),
         }
     }
 
@@ -103,6 +101,6 @@ fn main() {
 
     match dump_pdb(filename) {
         Ok(_) => (),
-        Err(e) => eprintln!("error dumping PDB: {}", e),
+        Err(e) => eprintln!("error dumping PDB: {e}"),
     }
 }

--- a/examples/stream_names.rs
+++ b/examples/stream_names.rs
@@ -20,6 +20,6 @@ fn main() {
 
     match dump_stream_names(&filename) {
         Ok(_) => (),
-        Err(e) => eprintln!("error dumping PDB: {}", e),
+        Err(e) => eprintln!("error dumping PDB: {e}"),
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -123,69 +123,61 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         match self {
             Self::PageReferenceOutOfRange(p) => {
-                write!(f, "MSF referred to page number ({}) out of range", p)
+                write!(f, "MSF referred to page number ({p}) out of range")
             }
             Self::InvalidPageSize(n) => write!(
                 f,
-                "The MSF header specifies an invalid page size ({} bytes)",
-                n
+                "The MSF header specifies an invalid page size ({n} bytes)"
             ),
             Self::StreamNotFound(s) => {
-                write!(f, "The requested stream ({}) is not stored in this file", s)
+                write!(f, "The requested stream ({s}) is not stored in this file")
             }
             Self::InvalidStreamLength(s) => write!(
                 f,
-                "{} stream has an invalid length or alignment for its records",
-                s
+                "{s} stream has an invalid length or alignment for its records"
             ),
-            Self::IoError(ref e) => write!(f, "IO error while reading PDB: {}", e),
+            Self::IoError(ref e) => write!(f, "IO error while reading PDB: {e}"),
             Self::UnimplementedFeature(feature) => {
-                write!(f, "Unimplemented PDB feature: {}", feature)
+                write!(f, "Unimplemented PDB feature: {feature}")
             }
             Self::UnimplementedSymbolKind(kind) => write!(
                 f,
-                "Support for symbols of kind {:#06x} is not implemented",
-                kind
+                "Support for symbols of kind {kind:#06x} is not implemented"
             ),
             Self::InvalidTypeInformationHeader(reason) => {
-                write!(f, "The type information header was invalid: {}", reason)
+                write!(f, "The type information header was invalid: {reason}")
             }
-            Self::TypeNotFound(type_index) => write!(f, "Type {} not found", type_index),
+            Self::TypeNotFound(type_index) => write!(f, "Type {type_index} not found"),
             Self::TypeNotIndexed(type_index, indexed_count) => write!(
                 f,
-                "Type {} not indexed (index covers {})",
-                type_index, indexed_count
+                "Type {type_index} not indexed (index covers {indexed_count})"
             ),
             Self::UnimplementedTypeKind(kind) => write!(
                 f,
-                "Support for types of kind {:#06x} is not implemented",
-                kind
+                "Support for types of kind {kind:#06x} is not implemented"
             ),
             Self::NotACrossModuleRef(index) => {
-                write!(f, "Type {:#06x} is not a cross module reference", index)
+                write!(f, "Type {index:#06x} is not a cross module reference")
             }
             Self::CrossModuleRefNotFound(index) => write!(
                 f,
-                "Cross module reference {:#06x} not found in imports",
-                index
+                "Cross module reference {index:#06x} not found in imports"
             ),
             Self::UnexpectedNumericPrefix(prefix) => write!(
                 f,
-                "Variable-length numeric parsing encountered an unexpected prefix ({:#06x}",
-                prefix
+                "Variable-length numeric parsing encountered an unexpected prefix ({prefix:#06x}"
             ),
             Self::UnimplementedDebugSubsection(kind) => write!(
                 f,
-                "Debug module subsection of kind {:#06x} is not implemented",
-                kind
+                "Debug module subsection of kind {kind:#06x} is not implemented"
             ),
             Self::UnimplementedFileChecksumKind(kind) => {
-                write!(f, "Unknown source file checksum kind {}", kind)
+                write!(f, "Unknown source file checksum kind {kind}")
             }
             Self::InvalidFileChecksumOffset(offset) => {
-                write!(f, "Invalid source file checksum offset {:#x}", offset)
+                write!(f, "Invalid source file checksum offset {offset:#x}")
             }
-            Self::UnknownBinaryAnnotation(num) => write!(f, "Unknown binary annotation {}", num),
+            Self::UnknownBinaryAnnotation(num) => write!(f, "Unknown binary annotation {num}"),
             _ => fmt::Debug::fmt(self, f),
         }
     }
@@ -266,6 +258,7 @@ macro_rules! impl_opt {
         impl $type {
             /// Returns an index that points to no value.
             #[inline]
+            #[must_use]
             pub const fn none() -> Self {
                 Self($none)
             }
@@ -299,32 +292,38 @@ macro_rules! impl_va {
     ($type:ty) => {
         impl $type {
             /// Checked addition of an offset. Returns `None` if overflow occurred.
+            #[must_use]
             pub fn checked_add(self, offset: u32) -> Option<Self> {
                 Some(Self(self.0.checked_add(offset)?))
             }
 
             /// Checked computation of an offset between two addresses. Returns `None` if `other` is
             /// larger.
+            #[must_use]
             pub fn checked_sub(self, other: Self) -> Option<u32> {
                 self.0.checked_sub(other.0)
             }
 
             /// Saturating addition of an offset, clipped at the numeric bounds.
+            #[must_use]
             pub fn saturating_add(self, offset: u32) -> Self {
                 Self(self.0.saturating_add(offset))
             }
 
             /// Saturating computation of an offset between two addresses, clipped at zero.
+            #[must_use]
             pub fn saturating_sub(self, other: Self) -> u32 {
                 self.0.saturating_sub(other.0)
             }
 
             /// Wrapping (modular) addition of an offset.
+            #[must_use]
             pub fn wrapping_add(self, offset: u32) -> Self {
                 Self(self.0.wrapping_add(offset))
             }
 
             /// Wrapping (modular) computation of an offset between two addresses.
+            #[must_use]
             pub fn wrapping_sub(self, other: Self) -> u32 {
                 self.0.wrapping_sub(other.0)
             }
@@ -388,11 +387,13 @@ macro_rules! impl_section_offset {
     ($type:ty) => {
         impl $type {
             /// Creates a new section offset.
+            #[must_use]
             pub fn new(section: u16, offset: u32) -> Self {
                 Self { offset, section }
             }
 
             /// Returns whether this section offset points to a valid section or into the void.
+            #[must_use]
             pub fn is_valid(self) -> bool {
                 self.section != 0
             }
@@ -401,6 +402,7 @@ macro_rules! impl_section_offset {
             ///
             /// This does not check whether the offset is still valid within the given section. If
             /// the offset is out of bounds, the conversion to `Rva` will return `None`.
+            #[must_use]
             pub fn checked_add(mut self, offset: u32) -> Option<Self> {
                 self.offset = self.offset.checked_add(offset)?;
                 Some(self)
@@ -410,6 +412,7 @@ macro_rules! impl_section_offset {
             ///
             /// This does not check whether the offset is still valid within the given section. If
             /// the offset is out of bounds, the conversion to `Rva` will return `None`.
+            #[must_use]
             pub fn saturating_add(mut self, offset: u32) -> Self {
                 self.offset = self.offset.saturating_add(offset);
                 self
@@ -419,6 +422,7 @@ macro_rules! impl_section_offset {
             ///
             /// This does not check whether the offset is still valid within the given section. If
             /// the offset is out of bounds, the conversion to `Rva` will return `None`.
+            #[must_use]
             pub fn wrapping_add(mut self, offset: u32) -> Self {
                 self.offset = self.offset.wrapping_add(offset);
                 self
@@ -548,7 +552,7 @@ impl StreamIndex {
 impl fmt::Display for StreamIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.msf_number() {
-            Some(number) => write!(f, "{}", number),
+            Some(number) => write!(f, "{number}"),
             None => write!(f, "None"),
         }
     }
@@ -556,7 +560,7 @@ impl fmt::Display for StreamIndex {
 
 impl fmt::Debug for StreamIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "StreamIndex({})", self)
+        write!(f, "StreamIndex({self})")
     }
 }
 
@@ -720,7 +724,7 @@ impl<'b> ParseBuffer<'b> {
         self.0.len() - self.1
     }
 
-    /// Determines whether this ParseBuffer has been consumed.
+    /// Determines whether this `ParseBuffer` has been consumed.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -835,11 +839,11 @@ impl<'b> From<&'b [u8]> for ParseBuffer<'b> {
     }
 }
 
-impl<'b> fmt::LowerHex for ParseBuffer<'b> {
+impl fmt::LowerHex for ParseBuffer<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> result::Result<(), fmt::Error> {
         write!(f, "ParseBuf::from(\"")?;
         for byte in self.0 {
-            write!(f, "\\x{:02x}", byte)?;
+            write!(f, "\\x{byte:02x}")?;
         }
         write!(f, "\").as_bytes() at offset {}", self.1)
     }
@@ -862,14 +866,14 @@ pub enum Variant {
 impl fmt::Display for Variant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::U8(value) => write!(f, "{}", value),
-            Self::U16(value) => write!(f, "{}", value),
-            Self::U32(value) => write!(f, "{}", value),
-            Self::U64(value) => write!(f, "{}", value),
-            Self::I8(value) => write!(f, "{}", value),
-            Self::I16(value) => write!(f, "{}", value),
-            Self::I32(value) => write!(f, "{}", value),
-            Self::I64(value) => write!(f, "{}", value),
+            Self::U8(value) => write!(f, "{value}"),
+            Self::U16(value) => write!(f, "{value}"),
+            Self::U32(value) => write!(f, "{value}"),
+            Self::U64(value) => write!(f, "{value}"),
+            Self::I8(value) => write!(f, "{value}"),
+            Self::I16(value) => write!(f, "{value}"),
+            Self::I32(value) => write!(f, "{value}"),
+            Self::I64(value) => write!(f, "{value}"),
         }
     }
 }
@@ -918,18 +922,21 @@ impl fmt::Display for RawString<'_> {
 impl<'b> RawString<'b> {
     /// Return the raw bytes of this string, as found in the PDB file.
     #[inline]
+    #[must_use]
     pub fn as_bytes(&self) -> &'b [u8] {
         self.0
     }
 
     /// Return the length of this string in bytes.
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Returns a boolean indicating if this string is empty.
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.len() == 0
     }
@@ -940,6 +947,7 @@ impl<'b> RawString<'b> {
     /// string was valid UTF-8. This is the expected case for strings that appear in PDB files,
     /// since they are almost always composed of printable 7-bit ASCII characters.
     #[inline]
+    #[must_use]
     pub fn to_string(&self) -> Cow<'b, str> {
         String::from_utf8_lossy(self.0)
     }
@@ -1234,13 +1242,13 @@ mod tests {
         #[test]
         fn test_format_newtype() {
             let val = SymbolIndex(0x42);
-            assert_eq!(format!("{}", val), "0x42");
+            assert_eq!(format!("{val}"), "0x42");
         }
 
         #[test]
         fn test_debug_newtype() {
             let val = SymbolIndex(0x42);
-            assert_eq!(format!("{:?}", val), "SymbolIndex(0x42)");
+            assert_eq!(format!("{val:?}"), "SymbolIndex(0x42)");
         }
 
         #[test]

--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -81,6 +81,7 @@ impl<'s> DebugInformation<'s> {
     /// checked for matching the image.
     ///
     /// [`PDBInformation::age`]: crate::PDBInformation::age
+    #[must_use]
     pub fn age(&self) -> Option<u32> {
         match self.header.age {
             0 => None,
@@ -90,10 +91,11 @@ impl<'s> DebugInformation<'s> {
 
     /// Returns whether or not this PDB has been marked as stripped. Stripped PDBs do not contain
     /// type information, line number information, or per-object CV symbols.
-    /// 
+    ///
     /// This flag is set when a PDB is written with [/PDBSTRIPPED] by MSVC.
-    /// 
+    ///
     /// [/PDBSTRIPPED]: https://learn.microsoft.com/en-us/cpp/build/reference/pdbstripped-strip-private-symbols?view=msvc-170
+    #[must_use]
     pub fn is_stripped(&self) -> bool {
         // flags.fStripped
         (self.header.flags & 0x2) != 0
@@ -258,7 +260,7 @@ impl DBIHeader {
             reserved: buf.parse_u32()?,
         };
 
-        if header.signature != u32::max_value() {
+        if header.signature != u32::MAX {
             // this is likely a DBIHdr, not a NewDBIHdr
             // it could be promoted:
             //   https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/PDB/dbi/dbi.cpp#L291-L313
@@ -514,6 +516,7 @@ impl<'m> Module<'m> {
     /// The module name.
     ///
     /// Usually either a full path to an object file or a string of the form `Import:<dll name>`.
+    #[must_use]
     pub fn module_name(&self) -> Cow<'m, str> {
         self.module_name.to_string()
     }
@@ -522,6 +525,7 @@ impl<'m> Module<'m> {
     /// May be the same as `module_name` for object files passed directly
     /// to the linker. For modules from static libraries, this is usually
     /// the full path to the archive.
+    #[must_use]
     pub fn object_file_name(&self) -> Cow<'m, str> {
         self.object_file_name.to_string()
     }
@@ -590,7 +594,7 @@ impl<'c> DBISectionContributionIter<'c> {
     }
 }
 
-impl<'c> FallibleIterator for DBISectionContributionIter<'c> {
+impl FallibleIterator for DBISectionContributionIter<'_> {
     type Item = DBISectionContribution;
     type Error = Error;
 
@@ -699,7 +703,7 @@ impl<'c> DBISectionMapIter<'c> {
     }
 }
 
-impl<'c> FallibleIterator for DBISectionMapIter<'c> {
+impl FallibleIterator for DBISectionMapIter<'_> {
     type Item = DBISectionMapItem;
     type Error = Error;
 

--- a/src/framedata.rs
+++ b/src/framedata.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! Facilities for parsing legacy FPO and FrameData streams.
+//! Facilities for parsing legacy FPO and `FrameData` streams.
 
 use std::cmp::Ordering;
 use std::fmt;
@@ -38,7 +38,7 @@ pub enum FrameType {
     /// Standard EBP stackframe.
     Standard = 3,
 
-    /// Frame pointer omitted, FrameData info available.
+    /// Frame pointer omitted, `FrameData` info available.
     FrameData = 4,
 }
 
@@ -169,7 +169,7 @@ impl fmt::Debug for NewFrameData {
 /// the layout of stack frames in the `dbgFPO` stream defined in the optional debug header. Since,
 /// it has been superseeded by the `tagFRAMEDATA` structure (see [`NewFrameData`]).
 ///
-/// Even if the newer FrameData stream is present, a PDB might still contain an additional FPO
+/// Even if the newer `FrameData` stream is present, a PDB might still contain an additional FPO
 /// stream. This is due to the fact that the linker simply copies over the stream. As a result, both
 /// stream might describe the same RVA.
 ///
@@ -524,6 +524,7 @@ impl<'s> FrameTable<'s> {
     }
 
     /// Returns an iterator over all frame data in this table, ordered by `code_rva`.
+    #[must_use]
     pub fn iter(&self) -> FrameDataIter<'_> {
         FrameDataIter {
             old_frames: self.old_frames(),
@@ -542,6 +543,7 @@ impl<'s> FrameTable<'s> {
     ///
     /// To obtain a `PdbInternalRva`, use [`PdbInternalSectionOffset::to_internal_rva`] or
     /// [`Rva::to_internal_rva`].
+    #[must_use]
     pub fn iter_at_rva(&self, rva: PdbInternalRva) -> FrameDataIter<'_> {
         let old_frames = self.old_frames();
         let old_index = binary_search_by_rva(old_frames, rva);
@@ -558,6 +560,7 @@ impl<'s> FrameTable<'s> {
     }
 
     /// Indicates whether any frame data is available.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.new_frames().is_empty() && self.old_frames().is_empty()
     }

--- a/src/modi/c13.rs
+++ b/src/modi/c13.rs
@@ -38,7 +38,9 @@ enum DebugSubsectionKind {
 impl DebugSubsectionKind {
     fn parse(value: u32) -> Result<Option<Self>> {
         if (0xf1..=0xfd).contains(&value) {
-            Ok(Some(unsafe { std::mem::transmute(value) }))
+            Ok(Some(unsafe {
+                std::mem::transmute::<u32, DebugSubsectionKind>(value)
+            }))
         } else if value == constants::DEBUG_S_IGNORE {
             Ok(None)
         } else {
@@ -149,7 +151,7 @@ pub struct InlineeSourceLine<'a> {
     extra_files: &'a [u8],
 }
 
-impl<'a> InlineeSourceLine<'a> {
+impl InlineeSourceLine<'_> {
     // TODO: Implement extra files iterator when needed.
 }
 
@@ -229,7 +231,7 @@ impl<'a> DebugInlineeLinesSubsection<'a> {
 struct DebugLinesHeader {
     /// Section offset of this line contribution.
     offset: PdbInternalSectionOffset,
-    /// See LineFlags enumeration.
+    /// See `LineFlags` enumeration.
     flags: u16,
     /// Code size of this line contribution.
     code_size: u32,
@@ -588,7 +590,7 @@ impl FileChecksumKind {
     /// Parses the checksum kind from its raw value.
     fn parse(value: u8) -> Result<Self> {
         if value <= 3 {
-            Ok(unsafe { std::mem::transmute(value) })
+            Ok(unsafe { std::mem::transmute::<u8, FileChecksumKind>(value) })
         } else {
             Err(Error::UnimplementedFileChecksumKind(value))
         }
@@ -908,7 +910,7 @@ impl Default for CrossModuleExportIter<'_> {
     }
 }
 
-impl<'a> FallibleIterator for CrossModuleExportIter<'a> {
+impl FallibleIterator for CrossModuleExportIter<'_> {
     type Item = CrossModuleExport;
     type Error = Error;
 
@@ -945,17 +947,20 @@ impl CrossModuleExports {
 
     /// Returns the number of exported types or ids from this module.
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.raw_exports.len()
     }
 
     /// Returns `true` if this module does not export types or ids.
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.raw_exports.is_empty()
     }
 
     /// Returns an iterator over all cross scope exports.
+    #[must_use]
     pub fn exports(&self) -> CrossModuleExportIter<'_> {
         CrossModuleExportIter {
             exports: self.raw_exports.iter(),
@@ -996,7 +1001,7 @@ pub struct LineIterator<'a> {
     last_info: Option<LineInfo>,
 }
 
-impl<'a> FallibleIterator for LineIterator<'a> {
+impl FallibleIterator for LineIterator<'_> {
     type Item = LineInfo;
     type Error = Error;
 
@@ -1128,7 +1133,7 @@ impl<'a> InlineeLineIterator<'a> {
     }
 }
 
-impl<'a> FallibleIterator for InlineeLineIterator<'a> {
+impl FallibleIterator for InlineeLineIterator<'_> {
     type Item = LineInfo;
     type Error = Error;
 
@@ -1238,6 +1243,7 @@ pub struct Inlinee<'a>(InlineeSourceLine<'a>);
 
 impl<'a> Inlinee<'a> {
     /// The index of this inlinee in the `IdInformation` stream (IPI).
+    #[must_use]
     pub fn index(&self) -> IdIndex {
         self.0.inlinee
     }
@@ -1247,6 +1253,7 @@ impl<'a> Inlinee<'a> {
     /// Note that line records are not guaranteed to be ordered by source code offset. If a
     /// monotonic order by `PdbInternalSectionOffset` or `Rva` is required, the lines have to be
     /// sorted manually.
+    #[must_use]
     pub fn lines(
         &self,
         parent_offset: PdbInternalSectionOffset,

--- a/src/modi/mod.rs
+++ b/src/modi/mod.rs
@@ -223,6 +223,7 @@ impl<'a> LineProgram<'a> {
     /// Note that line records are not guaranteed to be ordered by source code offset. If a
     /// monotonic order by `PdbInternalSectionOffset` or `Rva` is required, the lines have to be
     /// sorted manually.
+    #[must_use]
     pub fn lines(&self) -> LineIterator<'_> {
         match self.inner {
             LineProgramInner::C13(ref inner) => LineIterator {
@@ -232,6 +233,7 @@ impl<'a> LineProgram<'a> {
     }
 
     /// Returns an iterator over all file records of this module.
+    #[must_use]
     pub fn files(&self) -> FileIterator<'a> {
         match self.inner {
             LineProgramInner::C13(ref inner) => FileIterator {
@@ -250,6 +252,7 @@ impl<'a> LineProgram<'a> {
     /// Note that line records are not guaranteed to be ordered by source code offset. If a
     /// monotonic order by `PdbInternalSectionOffset` or `Rva` is required, the lines have to be
     /// sorted manually.
+    #[must_use]
     pub fn lines_for_symbol(&self, offset: PdbInternalSectionOffset) -> LineIterator<'_> {
         match self.inner {
             LineProgramInner::C13(ref inner) => LineIterator {
@@ -285,7 +288,7 @@ impl Default for LineIterator<'_> {
     }
 }
 
-impl<'a> FallibleIterator for LineIterator<'a> {
+impl FallibleIterator for LineIterator<'_> {
     type Item = LineInfo;
     type Error = Error;
 

--- a/src/msf/page_list.rs
+++ b/src/msf/page_list.rs
@@ -19,7 +19,7 @@ pub struct PageList {
 }
 
 impl PageList {
-    /// Create a new PageList for a given page size.
+    /// Create a new `PageList` for a given page size.
     pub fn new(page_size: usize) -> Self {
         Self {
             page_size,
@@ -29,7 +29,7 @@ impl PageList {
         }
     }
 
-    /// Add a page to the PageList. If this page number is sequential with the previous page number,
+    /// Add a page to the `PageList`. If this page number is sequential with the previous page number,
     /// it will be combined into the previous `SourceSlice` for efficiency.
     pub fn push(&mut self, page: PageNumber) {
         assert!(!self.truncated);
@@ -85,12 +85,12 @@ impl PageList {
         self.truncated = true;
     }
 
-    /// Return the total length of this PageList.
+    /// Return the total length of this `PageList`.
     pub fn len(&self) -> usize {
         self.source_slices.iter().fold(0, |acc, s| acc + s.size)
     }
 
-    /// Return a slice of SourceSlices.
+    /// Return a slice of `SourceSlices`.
     pub fn source_slices(&self) -> &[SourceSlice] {
         self.source_slices.as_slice()
     }

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -18,80 +18,80 @@ use crate::common::*;
 
 /// The section should not be padded to the next boundary. This flag is
 /// obsolete and is replaced by `IMAGE_SCN_ALIGN_1BYTES`.
-const IMAGE_SCN_TYPE_NO_PAD: u32 = 0x00000008;
+const IMAGE_SCN_TYPE_NO_PAD: u32 = 0x0000_0008;
 /// The section contains executable code.
-pub const IMAGE_SCN_CNT_CODE: u32 = 0x00000020;
+pub const IMAGE_SCN_CNT_CODE: u32 = 0x0000_0020;
 /// The section contains initialized data.
-const IMAGE_SCN_CNT_INITIALIZED_DATA: u32 = 0x00000040;
+const IMAGE_SCN_CNT_INITIALIZED_DATA: u32 = 0x0000_0040;
 /// The section contains uninitialized data.
-const IMAGE_SCN_CNT_UNINITIALIZED_DATA: u32 = 0x00000080;
+const IMAGE_SCN_CNT_UNINITIALIZED_DATA: u32 = 0x0000_0080;
 /// Reserved.
-const IMAGE_SCN_LNK_OTHER: u32 = 0x00000100;
+const IMAGE_SCN_LNK_OTHER: u32 = 0x0000_0100;
 /// The section contains comments or other information. This is valid only for object files.
-const IMAGE_SCN_LNK_INFO: u32 = 0x00000200;
+const IMAGE_SCN_LNK_INFO: u32 = 0x0000_0200;
 /// The section will not become part of the image. This is valid only for object files.
-const IMAGE_SCN_LNK_REMOVE: u32 = 0x00000800;
+const IMAGE_SCN_LNK_REMOVE: u32 = 0x0000_0800;
 /// The section contains COMDAT data. This is valid only for object files.
-const IMAGE_SCN_LNK_COMDAT: u32 = 0x00001000;
+const IMAGE_SCN_LNK_COMDAT: u32 = 0x0000_1000;
 /// Reset speculative exceptions handling bits in the TLB entries for this section.
-const IMAGE_SCN_NO_DEFER_SPEC_EXC: u32 = 0x00004000;
+const IMAGE_SCN_NO_DEFER_SPEC_EXC: u32 = 0x0000_4000;
 /// The section contains data referenced through the global pointer.
-const IMAGE_SCN_GPREL: u32 = 0x00008000;
+const IMAGE_SCN_GPREL: u32 = 0x0000_8000;
 /// Reserved.
-const IMAGE_SCN_MEM_PURGEABLE: u32 = 0x00020000;
+const IMAGE_SCN_MEM_PURGEABLE: u32 = 0x0002_0000;
 /// Reserved.
-const IMAGE_SCN_MEM_LOCKED: u32 = 0x00040000;
+const IMAGE_SCN_MEM_LOCKED: u32 = 0x0004_0000;
 /// Reserved.
-const IMAGE_SCN_MEM_PRELOAD: u32 = 0x00080000;
+const IMAGE_SCN_MEM_PRELOAD: u32 = 0x0008_0000;
 /// Align data on a 1-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_1BYTES: u32 = 0x00100000;
+const IMAGE_SCN_ALIGN_1BYTES: u32 = 0x0010_0000;
 /// Align data on a 2-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_2BYTES: u32 = 0x00200000;
+const IMAGE_SCN_ALIGN_2BYTES: u32 = 0x0020_0000;
 /// Align data on a 4-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_4BYTES: u32 = 0x00300000;
+const IMAGE_SCN_ALIGN_4BYTES: u32 = 0x0030_0000;
 /// Align data on a 8-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_8BYTES: u32 = 0x00400000;
+const IMAGE_SCN_ALIGN_8BYTES: u32 = 0x0040_0000;
 /// Align data on a 16-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_16BYTES: u32 = 0x00500000;
+const IMAGE_SCN_ALIGN_16BYTES: u32 = 0x0050_0000;
 /// Align data on a 32-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_32BYTES: u32 = 0x00600000;
+const IMAGE_SCN_ALIGN_32BYTES: u32 = 0x0060_0000;
 /// Align data on a 64-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_64BYTES: u32 = 0x00700000;
+const IMAGE_SCN_ALIGN_64BYTES: u32 = 0x0070_0000;
 /// Align data on a 128-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_128BYTES: u32 = 0x00800000;
+const IMAGE_SCN_ALIGN_128BYTES: u32 = 0x0080_0000;
 /// Align data on a 256-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_256BYTES: u32 = 0x00900000;
+const IMAGE_SCN_ALIGN_256BYTES: u32 = 0x0090_0000;
 /// Align data on a 512-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_512BYTES: u32 = 0x00A00000;
+const IMAGE_SCN_ALIGN_512BYTES: u32 = 0x00A0_0000;
 /// Align data on a 1024-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_1024BYTES: u32 = 0x00B00000;
+const IMAGE_SCN_ALIGN_1024BYTES: u32 = 0x00B0_0000;
 /// Align data on a 2048-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_2048BYTES: u32 = 0x00C00000;
+const IMAGE_SCN_ALIGN_2048BYTES: u32 = 0x00C0_0000;
 /// Align data on a 4096-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_4096BYTES: u32 = 0x00D00000;
+const IMAGE_SCN_ALIGN_4096BYTES: u32 = 0x00D0_0000;
 /// Align data on a 8192-byte boundary. This is valid only for object files.
-const IMAGE_SCN_ALIGN_8192BYTES: u32 = 0x00E00000;
+const IMAGE_SCN_ALIGN_8192BYTES: u32 = 0x00E0_0000;
 /// The section contains extended relocations. The count of relocations for the
 /// section exceeds the 16 bits that is reserved for it in the section header.
 /// If the `number_of_relocations` field in the section header is `0xffff`, the
 /// actual relocation count is stored in the `virtual_address` field of the first
 /// relocation. It is an error if `IMAGE_SCN_LNK_NRELOC_OVFL` is set and there
 /// are fewer than `0xffff` relocations in the section.
-const IMAGE_SCN_LNK_NRELOC_OVFL: u32 = 0x01000000;
+const IMAGE_SCN_LNK_NRELOC_OVFL: u32 = 0x0100_0000;
 /// The section can be discarded as needed.
-const IMAGE_SCN_MEM_DISCARDABLE: u32 = 0x02000000;
+const IMAGE_SCN_MEM_DISCARDABLE: u32 = 0x0200_0000;
 /// The section cannot be cached.
-const IMAGE_SCN_MEM_NOT_CACHED: u32 = 0x04000000;
+const IMAGE_SCN_MEM_NOT_CACHED: u32 = 0x0400_0000;
 /// The section cannot be paged.
-const IMAGE_SCN_MEM_NOT_PAGED: u32 = 0x08000000;
+const IMAGE_SCN_MEM_NOT_PAGED: u32 = 0x0800_0000;
 /// The section can be shared in memory.
-const IMAGE_SCN_MEM_SHARED: u32 = 0x10000000;
+const IMAGE_SCN_MEM_SHARED: u32 = 0x1000_0000;
 /// The section can be executed as code.
-pub const IMAGE_SCN_MEM_EXECUTE: u32 = 0x20000000;
+pub const IMAGE_SCN_MEM_EXECUTE: u32 = 0x2000_0000;
 /// The section can be read.
-pub const IMAGE_SCN_MEM_READ: u32 = 0x40000000;
+pub const IMAGE_SCN_MEM_READ: u32 = 0x4000_0000;
 /// The section can be written to.
-pub const IMAGE_SCN_MEM_WRITE: u32 = 0x80000000;
+pub const IMAGE_SCN_MEM_WRITE: u32 = 0x8000_0000;
 
 /// Characteristic flags of an [`ImageSectionHeader`].
 ///
@@ -103,61 +103,73 @@ pub struct SectionCharacteristics(pub u32);
 
 impl SectionCharacteristics {
     /// The section contains executable code.
+    #[must_use]
     pub fn executable(self) -> bool {
         (self.0 & IMAGE_SCN_CNT_CODE) > 0
     }
 
     /// The section contains initialized data.
+    #[must_use]
     pub fn initialized_data(self) -> bool {
         (self.0 & IMAGE_SCN_CNT_INITIALIZED_DATA) > 0
     }
 
     /// The section contains uninitialized data.
+    #[must_use]
     pub fn uninitialized_data(self) -> bool {
         (self.0 & IMAGE_SCN_CNT_UNINITIALIZED_DATA) > 0
     }
 
     /// Reserved.
+    #[must_use]
     pub fn other(self) -> bool {
         (self.0 & IMAGE_SCN_LNK_OTHER) > 0
     }
 
     /// The section contains comments or other information. This is valid only for object files.
+    #[must_use]
     pub fn info(self) -> bool {
         (self.0 & IMAGE_SCN_LNK_INFO) > 0
     }
 
     /// The section will not become part of the image. This is valid only for object files.
+    #[must_use]
     pub fn remove(self) -> bool {
         (self.0 & IMAGE_SCN_LNK_REMOVE) > 0
     }
 
     /// The section contains COMDAT data. This is valid only for object files.
+    #[must_use]
     pub fn comdat(self) -> bool {
         (self.0 & IMAGE_SCN_LNK_COMDAT) > 0
     }
 
     /// Reset speculative exceptions handling bits in the TLB entries for this section.
+    #[must_use]
     pub fn defer_speculative_exceptions(self) -> bool {
         (self.0 & IMAGE_SCN_NO_DEFER_SPEC_EXC) > 0
     }
 
     /// The section contains data referenced through the global pointer.
+    #[must_use]
     pub fn global_pointer_relative(self) -> bool {
         (self.0 & IMAGE_SCN_GPREL) > 0
     }
 
     /// Reserved.
+    #[must_use]
     pub fn purgeable(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_PURGEABLE) > 0
     }
 
     /// Reserved.
+    #[must_use]
     pub fn locked(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_LOCKED) > 0
     }
 
     /// Reserved.
+    #[must_use]
     pub fn preload(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_PRELOAD) > 0
     }
@@ -167,9 +179,10 @@ impl SectionCharacteristics {
     /// This is valid only for object files. Returns `Some` if alignment is specified, and `None` if
     /// no alignment is specified. An alignment of `Some(1)` means that the section should not be
     /// padded to a boundary.
+    #[must_use]
     pub fn alignment(self) -> Option<u16> {
         // Mask covering all align values and IMAGE_SCN_TYPE_NO_PAD.
-        match self.0 & 0x00F00008 {
+        match self.0 & 0x00F0_0008 {
             self::IMAGE_SCN_ALIGN_1BYTES => Some(1),
             self::IMAGE_SCN_ALIGN_2BYTES => Some(2),
             self::IMAGE_SCN_ALIGN_4BYTES => Some(4),
@@ -196,41 +209,49 @@ impl SectionCharacteristics {
     /// field in the section header is `0xffff`, the actual relocation count is stored in the
     /// `virtual_address` field of the first relocation. It is an error if this flag is set and
     /// there are fewer than `0xffff` relocations in the section.
+    #[must_use]
     pub fn lnk_nreloc_ovfl(self) -> bool {
         (self.0 & IMAGE_SCN_LNK_NRELOC_OVFL) > 0
     }
 
     /// The section can be discarded as needed.
+    #[must_use]
     pub fn discardable(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_DISCARDABLE) > 0
     }
 
     /// The section cannot be cached.
+    #[must_use]
     pub fn not_cached(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_NOT_CACHED) > 0
     }
 
     /// The section cannot be paged.
+    #[must_use]
     pub fn not_paged(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_NOT_PAGED) > 0
     }
 
     /// The section can be shared in memory.
+    #[must_use]
     pub fn shared(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_SHARED) > 0
     }
 
     /// The section can be executed as code.
+    #[must_use]
     pub fn execute(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_EXECUTE) > 0
     }
 
     /// The section can be read.
+    #[must_use]
     pub fn read(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_READ) > 0
     }
 
     /// The section can be written to.
+    #[must_use]
     pub fn write(self) -> bool {
         (self.0 & IMAGE_SCN_MEM_WRITE) > 0
     }
@@ -369,6 +390,7 @@ impl ImageSectionHeader {
     }
 
     /// Returns the name of the section.
+    #[must_use]
     pub fn name(&self) -> &str {
         let end = self
             .name

--- a/src/source.rs
+++ b/src/source.rs
@@ -49,7 +49,7 @@ pub struct SourceSlice {
 pub trait Source<'s>: fmt::Debug {
     /// Provides a contiguous view of the source file composed of the requested position(s).
     ///
-    /// Note that the SourceView's as_slice() method cannot fail, so `view()` is the time to raise
+    /// Note that the `SourceView`'s `as_slice()` method cannot fail, so `view()` is the time to raise
     /// IO errors.
     fn view(
         &mut self,

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -123,7 +123,7 @@ impl<'s> StringTable<'s> {
     }
 }
 
-impl<'s> StringTable<'s> {
+impl StringTable<'_> {
     /// Resolves a string value from this string table.
     ///
     /// Errors if the offset is out of bounds, otherwise returns the raw binary string value.

--- a/src/symbol/annotations.rs
+++ b/src/symbol/annotations.rs
@@ -1,7 +1,7 @@
 use crate::common::*;
 use crate::FallibleIterator;
 
-/// These values correspond to the BinaryAnnotationOpcode enum from the
+/// These values correspond to the `BinaryAnnotationOpcode` enum from the
 /// cvinfo.h
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BinaryAnnotationOpcode {
@@ -31,7 +31,7 @@ enum BinaryAnnotationOpcode {
     ChangeColumnStart = 9,
     /// param : end column number delta (signed)
     ChangeColumnEndDelta = 10,
-    /// param : ((sourceDelta << 4) | CodeDelta)
+    /// param : ((sourceDelta << 4) | `CodeDelta`)
     ChangeCodeOffsetAndLineOffset = 11,
     /// param : codeLength, codeOffset
     ChangeCodeLengthAndCodeOffset = 12,
@@ -109,6 +109,7 @@ pub enum BinaryAnnotation {
 
 impl BinaryAnnotation {
     /// Does this annotation emit a line info?
+    #[must_use]
     pub fn emits_line_info(self) -> bool {
         matches!(
             self,
@@ -125,7 +126,7 @@ pub struct BinaryAnnotationsIter<'t> {
     buffer: ParseBuffer<'t>,
 }
 
-impl<'t> BinaryAnnotationsIter<'t> {
+impl BinaryAnnotationsIter<'_> {
     /// Parse a compact version of an unsigned integer.
     ///
     /// This implements `CVUncompressData`, which can decode numbers no larger than 0x1FFFFFFF. It
@@ -163,7 +164,7 @@ fn decode_signed_operand(value: u32) -> i32 {
     }
 }
 
-impl<'t> FallibleIterator for BinaryAnnotationsIter<'t> {
+impl FallibleIterator for BinaryAnnotationsIter<'_> {
     type Item = BinaryAnnotation;
     type Error = Error;
 
@@ -244,11 +245,13 @@ pub struct BinaryAnnotations<'t> {
 
 impl<'t> BinaryAnnotations<'t> {
     /// Creates a new instance of binary annotations.
+    #[must_use]
     pub(crate) fn new(data: &'t [u8]) -> Self {
         BinaryAnnotations { data }
     }
 
     /// Iterates through binary annotations.
+    #[must_use]
     pub fn iter(&self) -> BinaryAnnotationsIter<'t> {
         BinaryAnnotationsIter {
             buffer: ParseBuffer::from(self.data),

--- a/src/symbol/constants.rs
+++ b/src/symbol/constants.rs
@@ -271,7 +271,7 @@ pub const S_LDATA_HLSL32_EX: u16 = 0x1165;
 pub const S_FASTLINK: u16 = 0x1167; // generated at link time for /DEBUG:FASTLINK
 pub const S_INLINEES: u16 = 0x1168;
 
-/// These values correspond to the CV_CPU_TYPE_e enumeration, and are documented
+/// These values correspond to the `CV_CPU_TYPE_e` enumeration, and are documented
 /// [on MSDN](https://msdn.microsoft.com/en-us/library/b2fc64ek.aspx).
 #[non_exhaustive]
 #[allow(missing_docs)]
@@ -482,7 +482,7 @@ impl<'a> TryFromCtx<'a, Endian> for CPUType {
     }
 }
 
-/// These values correspond to the CV_CFL_LANG enumeration, and are documented
+/// These values correspond to the `CV_CFL_LANG` enumeration, and are documented
 /// [on MSDN](https://learn.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/cv-cfl-lang?view=vs-2022).
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/tpi/data.rs
+++ b/src/tpi/data.rs
@@ -43,7 +43,8 @@ pub enum TypeData<'t> {
 }
 
 impl<'t> TypeData<'t> {
-    /// Return the name of this TypeData, if any
+    /// Return the name of this `TypeData`, if any
+    #[must_use]
     pub fn name(&self) -> Option<RawString<'t>> {
         let name = match self {
             Self::Class(ClassType { ref name, .. })
@@ -289,7 +290,7 @@ pub(crate) fn parse_type_data<'t>(buf: &mut ParseBuffer<'t>) -> Result<TypeData<
 
             loop {
                 let dim = parse_unsigned(buf)?;
-                if dim > u64::from(u32::max_value()) {
+                if dim > u64::from(u32::MAX) {
                     return Err(Error::UnimplementedFeature("u64 array sizes"));
                 }
                 dimensions.push(dim as u32);
@@ -557,34 +558,42 @@ unsigned short  mocom       :2;     // CV_MOCOM_UDT_e
 pub struct TypeProperties(u16);
 impl TypeProperties {
     /// Indicates if a type is packed via `#pragma pack` or similar.
+    #[must_use]
     pub fn packed(self) -> bool {
         self.0 & 0x0001 != 0
     }
 
     /// Indicates if a type has constructors or destructors.
+    #[must_use]
     pub fn constructors(self) -> bool {
         self.0 & 0x0002 != 0
     }
 
     /// Indicates if a type has any overloaded operators.
+    #[must_use]
     pub fn overloaded_operators(self) -> bool {
         self.0 & 0x0004 != 0
     }
 
     /// Indicates if a type is a nested type, e.g. a `union` defined inside a `class`.
+    #[must_use]
     pub fn is_nested_type(self) -> bool {
         self.0 & 0x0008 != 0
     }
 
     /// Indicates if a type contains nested types.
+    #[must_use]
     pub fn contains_nested_types(self) -> bool {
         self.0 & 0x0010 != 0
     }
 
     /// Indicates if a class has overloaded the assignment operator.
+    #[must_use]
     pub fn overloaded_assignment(self) -> bool {
         self.0 & 0x0020 != 0
     }
+
+    #[must_use]
     pub fn overloaded_casting(self) -> bool {
         self.0 & 0x0040 != 0
     }
@@ -593,25 +602,37 @@ impl TypeProperties {
     /// placeholder until a complete Type can be built. This is necessary for e.g. self-referential
     /// data structures, but other more common declaration/definition idioms can cause forward
     /// references too.
+    #[must_use]
     pub fn forward_reference(self) -> bool {
         self.0 & 0x0080 != 0
     }
 
+    #[must_use]
     pub fn scoped_definition(self) -> bool {
         self.0 & 0x0100 != 0
     }
+
+    #[must_use]
     pub fn has_unique_name(self) -> bool {
         self.0 & 0x0200 != 0
     }
+
+    #[must_use]
     pub fn sealed(self) -> bool {
         self.0 & 0x0400 != 0
     }
+
+    #[must_use]
     pub fn hfa(self) -> u8 {
         ((self.0 & 0x1800) >> 11) as u8
     }
+
+    #[must_use]
     pub fn intrinsic_type(self) -> bool {
         self.0 & 0x1000 != 0
     }
+
+    #[must_use]
     pub fn mocom(self) -> u8 {
         ((self.0 & 0x6000) >> 14) as u8
     }
@@ -644,55 +665,67 @@ typedef enum CV_methodprop_e {
 pub struct FieldAttributes(u16);
 impl FieldAttributes {
     #[inline]
+    #[must_use]
     pub fn access(self) -> u8 {
         (self.0 & 0x0003) as u8
     }
+
     #[inline]
+    #[must_use]
     fn method_properties(self) -> u8 {
         ((self.0 & 0x001c) >> 2) as u8
     }
 
     #[inline]
+    #[must_use]
     pub fn is_static(self) -> bool {
         self.method_properties() == 0x02
     }
 
     #[inline]
+    #[must_use]
     pub fn is_virtual(self) -> bool {
         self.method_properties() == 0x01
     }
 
     #[inline]
+    #[must_use]
     pub fn is_pure_virtual(self) -> bool {
         self.method_properties() == 0x05
     }
 
     #[inline]
+    #[must_use]
     pub fn is_intro_virtual(self) -> bool {
         matches!(self.method_properties(), 0x04 | 0x06)
     }
 
     #[inline]
+    #[must_use]
     pub fn is_pseudo(self) -> bool {
         self.0 & 0x0020 != 0
     }
 
     #[inline]
+    #[must_use]
     pub fn noinherit(self) -> bool {
         self.0 & 0x0040 != 0
     }
 
     #[inline]
+    #[must_use]
     pub fn noconstruct(self) -> bool {
         self.0 & 0x0080 != 0
     }
 
     #[inline]
+    #[must_use]
     pub fn is_compgenx(self) -> bool {
         self.0 & 0x0100 != 0
     }
 
     #[inline]
+    #[must_use]
     pub fn sealed(self) -> bool {
         self.0 & 0x0200 != 0
     }
@@ -722,15 +755,22 @@ typedef struct CV_funcattr_t {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct FunctionAttributes(u16);
 impl FunctionAttributes {
+    #[must_use]
     pub fn calling_convention(self) -> u8 {
         (self.0 & 0xff) as u8
     }
+
+    #[must_use]
     pub fn cxx_return_udt(self) -> bool {
         (self.0 & 0x0100) > 0
     }
+
+    #[must_use]
     pub fn is_constructor(self) -> bool {
         (self.0 & 0x0200) > 0
     }
+
+    #[must_use]
     pub fn is_constructor_with_virtual_bases(self) -> bool {
         (self.0 & 0x0400) > 0
     }
@@ -804,6 +844,7 @@ pub struct PointerAttributes(u32);
 
 impl PointerAttributes {
     /// Indicates the type of pointer.
+    #[must_use]
     pub fn pointer_kind(self) -> PointerKind {
         match self.0 & 0x1f {
             0x00 => PointerKind::Near16,
@@ -824,6 +865,7 @@ impl PointerAttributes {
     }
 
     /// Returns the mode of this pointer.
+    #[must_use]
     pub fn pointer_mode(self) -> PointerMode {
         match (self.0 >> 5) & 0x7 {
             0x00 => PointerMode::Pointer,
@@ -836,6 +878,7 @@ impl PointerAttributes {
     }
 
     /// Returns `true` if this points to a member (either data or function).
+    #[must_use]
     pub fn pointer_to_member(self) -> bool {
         matches!(
             self.pointer_mode(),
@@ -844,31 +887,37 @@ impl PointerAttributes {
     }
 
     /// Returns `true` if this is a flat `0:32` pointer.
+    #[must_use]
     pub fn is_flat_32(self) -> bool {
         (self.0 & 0x100) != 0
     }
 
     /// Returns `true` if this pointer is `volatile`.
+    #[must_use]
     pub fn is_volatile(self) -> bool {
         (self.0 & 0x200) != 0
     }
 
     /// Returns `true` if this pointer is `const`.
+    #[must_use]
     pub fn is_const(self) -> bool {
         (self.0 & 0x400) != 0
     }
 
     /// Returns `true` if this pointer is unaligned.
+    #[must_use]
     pub fn is_unaligned(self) -> bool {
         (self.0 & 0x800) != 0
     }
 
     /// Returns `true` if this pointer is restricted (allow aggressive opts).
+    #[must_use]
     pub fn is_restrict(self) -> bool {
         (self.0 & 0x1000) != 0
     }
 
     /// Is this a C++ reference, as opposed to a C pointer?
+    #[must_use]
     pub fn is_reference(self) -> bool {
         matches!(
             self.pointer_mode(),
@@ -877,6 +926,7 @@ impl PointerAttributes {
     }
 
     /// The size of the pointer in bytes.
+    #[must_use]
     pub fn size(self) -> u8 {
         let size = ((self.0 >> 13) & 0x3f) as u8;
         if size != 0 {
@@ -890,7 +940,8 @@ impl PointerAttributes {
         }
     }
 
-    /// Returns `true` if this is a MoCOM pointer (`^` or `%`).
+    /// Returns `true` if this is a `MoCOM` pointer (`^` or `%`).
+    #[must_use]
     pub fn is_mocom(self) -> bool {
         (self.0 & 0x40000) != 0
     }
@@ -1173,8 +1224,8 @@ pub struct BitfieldType {
 pub struct FieldList<'t> {
     pub fields: Vec<TypeData<'t>>,
 
-    /// Sometimes fields can't all fit in a single FieldList, in which case the FieldList
-    /// refers to another FieldList in a chain.
+    /// Sometimes fields can't all fit in a single `FieldList`, in which case the `FieldList`
+    /// refers to another `FieldList` in a chain.
     pub continuation: Option<TypeIndex>,
 }
 

--- a/src/tpi/id.rs
+++ b/src/tpi/id.rs
@@ -38,7 +38,7 @@ pub enum IdData<'t> {
     UserDefinedTypeSource(UserDefinedTypeSourceId),
 }
 
-impl<'t> IdData<'t> {}
+impl IdData<'_> {}
 
 impl<'t> TryFromCtx<'t, scroll::Endian> for IdData<'t> {
     type Error = Error;

--- a/src/tpi/mod.rs
+++ b/src/tpi/mod.rs
@@ -148,6 +148,7 @@ where
     }
 
     /// Returns an iterator that can traverse the type table in sequential order.
+    #[must_use]
     pub fn iter(&self) -> ItemIter<'_, I> {
         // get a parse buffer
         let mut buf = self.stream.parse_buffer();
@@ -169,11 +170,13 @@ where
     /// Note that in the case of the type stream ([`TypeInformation`]) primitive types are not
     /// stored in the PDB file. The number of distinct types reachable via this table will be higher
     /// than `len()`.
+    #[must_use]
     pub fn len(&self) -> usize {
         (self.header.maximum_index - self.header.minimum_index) as usize
     }
 
     /// Returns whether this `ItemInformation` contains any data.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -183,6 +186,7 @@ where
     ///
     /// The `ItemFinder` is initially empty and must be populated by iterating. See the struct-level
     /// docs for an example.
+    #[must_use]
     pub fn finder(&self) -> ItemFinder<'_, I> {
         ItemFinder::new(self, 3)
     }
@@ -211,7 +215,7 @@ pub struct Item<'t, I> {
     data: &'t [u8],
 }
 
-impl<'t, I> Item<'t, I>
+impl<I> Item<'_, I>
 where
     I: ItemIndex,
 {
@@ -248,7 +252,7 @@ where
     }
 }
 
-impl<'t, I> fmt::Debug for Item<'t, I>
+impl<I> fmt::Debug for Item<'_, I>
 where
     I: ItemIndex,
 {
@@ -365,6 +369,7 @@ where
     /// reference lower indexes. However, when loading items referenced by the symbols stream, this
     /// can be useful to check whether iteration is required.
     #[inline]
+    #[must_use]
     pub fn max_index(&self) -> I {
         I::from(match self.positions.len() {
             0 => 0, // special case for an empty type index
@@ -381,7 +386,7 @@ where
         let (vec_index, iteration_count) = self.resolve(iterator.index);
         if iteration_count == 0 && vec_index == self.positions.len() {
             let pos = iterator.buf.pos();
-            assert!(pos < u32::max_value() as usize);
+            assert!(pos < u32::MAX as usize);
             self.positions.push(pos as u32);
         }
     }

--- a/tests/id_information.rs
+++ b/tests/id_information.rs
@@ -1,4 +1,4 @@
-//! Tests that IdInformation works on files where the IPI is missing (empty stream).
+//! Tests that `IdInformation` works on files where the IPI is missing (empty stream).
 
 use pdb2 as pdb;
 

--- a/tests/symbol_table.rs
+++ b/tests/symbol_table.rs
@@ -58,7 +58,7 @@ fn count_symbols() {
 
         println!("symbol counts by kind:");
         for (kind, count) in &map {
-            println!("  - kind: 0x{:04x}, count: {}", kind, count);
+            println!("  - kind: 0x{kind:04x}, count: {count}");
         }
 
         assert!(*map.get(&0x1107).expect("0x1107") >= 500);

--- a/tests/type_information.rs
+++ b/tests/type_information.rs
@@ -93,18 +93,18 @@ fn find_classes() {
                     match type_finder.find(fields).expect("find fields").parse() {
                         Ok(pdb::TypeData::FieldList(list)) => {
                             for field in list.fields {
-                                println!("  - {:?}", field);
+                                println!("  - {field:?}");
                             }
 
                             if let Some(c) = list.continuation {
-                                println!("TODO: follow to type {}", c);
+                                println!("TODO: follow to type {c}");
                             }
                         }
                         Ok(value) => {
                             panic!("expected a field list, got {:?}", value);
                         }
                         Err(e) => {
-                            println!("field parse error: {}", e);
+                            println!("field parse error: {e}");
                         }
                     }
                 }
@@ -115,18 +115,18 @@ fn find_classes() {
                     match type_finder.find(data.fields).expect("find fields").parse() {
                         Ok(pdb::TypeData::FieldList(list)) => {
                             for field in list.fields {
-                                println!("  - {:?}", field);
+                                println!("  - {field:?}");
                             }
 
                             if let Some(c) = list.continuation {
-                                println!("TODO: follow to type {}", c);
+                                println!("TODO: follow to type {c}");
                             }
                         }
                         Ok(value) => {
                             panic!("expected a field list, got {:?}", value);
                         }
                         Err(e) => {
-                            println!("field parse error: {}", e);
+                            println!("field parse error: {e}");
                         }
                     }
                 }
@@ -137,7 +137,7 @@ fn find_classes() {
                     //println!("type: {:?}", data);
                 }
                 Err(pdb::Error::UnimplementedTypeKind(kind)) => {
-                    println!("unimplemented: 0x{:04x}", kind);
+                    println!("unimplemented: 0x{kind:04x}");
                     // TODO: parse everything
                     // ignore for now
                 }


### PR DESCRIPTION
This commit fixes all of the default-enabled warnings, as well as many of the warnings in pedantic mode.

I got a mail for every push from the CI workflow, which complained about clippy, so it made sense to fix this first.