### PR TITLE
Vector35 improvements part 2

### DIFF
--- a/src/dbi.rs
+++ b/src/dbi.rs
@@ -29,7 +29,6 @@ use crate::{FallibleIterator, SectionCharacteristics};
 /// let mut pdb = pdb2::PDB::open(file)?;
 ///
 /// let dbi = pdb.debug_information()?;
-
 ///
 /// # let mut count: usize = 0;
 /// let mut modules = dbi.modules()?;

--- a/src/symbol/constants.rs
+++ b/src/symbol/constants.rs
@@ -16,17 +16,17 @@ use std::fmt;
 use scroll::{ctx::TryFromCtx, Endian};
 
 pub const S_COMPILE: u16 = 0x0001; // Compile flags symbol
-pub const S_REGISTER_16t: u16 = 0x0002; // Register variable
-pub const S_CONSTANT_16t: u16 = 0x0003; // constant symbol
-pub const S_UDT_16t: u16 = 0x0004; // User defined type
+pub const S_REGISTER_16T: u16 = 0x0002; // Register variable
+pub const S_CONSTANT_16T: u16 = 0x0003; // constant symbol
+pub const S_UDT_16T: u16 = 0x0004; // User defined type
 pub const S_SSEARCH: u16 = 0x0005; // Start Search
 pub const S_END: u16 = 0x0006; // Block procedure "with" or thunk end
 pub const S_SKIP: u16 = 0x0007; // Reserve symbol space in $$Symbols table
 pub const S_CVRESERVE: u16 = 0x0008; // Reserved symbol for CV internal use
 pub const S_OBJNAME_ST: u16 = 0x0009; // path to object file name
 pub const S_ENDARG: u16 = 0x000a; // end of argument/return list
-pub const S_COBOLUDT_16t: u16 = 0x000b; // special UDT for cobol that does not symbol pack
-pub const S_MANYREG_16t: u16 = 0x000c; // multiple register variable
+pub const S_COBOLUDT_16T: u16 = 0x000b; // special UDT for cobol that does not symbol pack
+pub const S_MANYREG_16T: u16 = 0x000c; // multiple register variable
 pub const S_RETURN: u16 = 0x000d; // return description symbol
 pub const S_ENTRYTHIS: u16 = 0x000e; // description of this pointer on entry
 
@@ -44,25 +44,25 @@ pub const S_CEXMODEL16: u16 = 0x010a; // change execution model
 pub const S_VFTABLE16: u16 = 0x010b; // address of virtual function table
 pub const S_REGREL16: u16 = 0x010c; // register relative address
 
-pub const S_BPREL32_16t: u16 = 0x0200; // BP-relative
-pub const S_LDATA32_16t: u16 = 0x0201; // Module-local symbol
-pub const S_GDATA32_16t: u16 = 0x0202; // Global data symbol
-pub const S_PUB32_16t: u16 = 0x0203; // a public symbol (CV internal reserved)
-pub const S_LPROC32_16t: u16 = 0x0204; // Local procedure start
-pub const S_GPROC32_16t: u16 = 0x0205; // Global procedure start
+pub const S_BPREL32_16T: u16 = 0x0200; // BP-relative
+pub const S_LDATA32_16T: u16 = 0x0201; // Module-local symbol
+pub const S_GDATA32_16T: u16 = 0x0202; // Global data symbol
+pub const S_PUB32_16T: u16 = 0x0203; // a public symbol (CV internal reserved)
+pub const S_LPROC32_16T: u16 = 0x0204; // Local procedure start
+pub const S_GPROC32_16T: u16 = 0x0205; // Global procedure start
 pub const S_THUNK32_ST: u16 = 0x0206; // Thunk Start
 pub const S_BLOCK32_ST: u16 = 0x0207; // block start
 pub const S_WITH32_ST: u16 = 0x0208; // with start
 pub const S_LABEL32_ST: u16 = 0x0209; // code label
 pub const S_CEXMODEL32: u16 = 0x020a; // change execution model
-pub const S_VFTABLE32_16t: u16 = 0x020b; // address of virtual function table
-pub const S_REGREL32_16t: u16 = 0x020c; // register relative address
-pub const S_LTHREAD32_16t: u16 = 0x020d; // local thread storage
-pub const S_GTHREAD32_16t: u16 = 0x020e; // global thread storage
+pub const S_VFTABLE32_16T: u16 = 0x020b; // address of virtual function table
+pub const S_REGREL32_16T: u16 = 0x020c; // register relative address
+pub const S_LTHREAD32_16T: u16 = 0x020d; // local thread storage
+pub const S_GTHREAD32_16T: u16 = 0x020e; // global thread storage
 pub const S_SLINK32: u16 = 0x020f; // static link for MIPS EH implementation
 
-pub const S_LPROCMIPS_16t: u16 = 0x0300; // Local procedure start
-pub const S_GPROCMIPS_16t: u16 = 0x0301; // Global procedure start
+pub const S_LPROCMIPS_16T: u16 = 0x0300; // Local procedure start
+pub const S_GPROCMIPS_16T: u16 = 0x0301; // Global procedure start
 
 // if these ref symbols have names following then the names are in ST format
 pub const S_PROCREF_ST: u16 = 0x0400; // Reference to a procedure

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -255,6 +255,10 @@ pub enum SymbolData<'t> {
     DefRangeSubFieldRegister(DefRangeSubFieldRegisterSymbol),
     /// A live range of a variable related to a register.
     DefRangeRegisterRelative(DefRangeRegisterRelativeSymbol),
+    /// A base pointer-relative variable.
+    BasePointerRelative(BasePointerRelativeSymbol<'t>),
+    /// Extra frame and proc information.
+    FrameProcedure(FrameProcedureSymbol),
 }
 
 impl<'t> SymbolData<'t> {
@@ -284,6 +288,7 @@ impl<'t> SymbolData<'t> {
             Self::Thunk(data) => Some(data.name),
             Self::Section(data) => Some(data.name),
             Self::CoffGroup(data) => Some(data.name),
+            Self::BasePointerRelative(data) => Some(data.name),
             Self::ScopeEnd
             | Self::RegisterVariable(_)
             | Self::MultiRegisterVariable(_)
@@ -302,7 +307,8 @@ impl<'t> SymbolData<'t> {
             | Self::DefRangeFramePointerRelative(_)
             | Self::DefRangeFramePointerRelativeFullScope(_)
             | Self::DefRangeSubFieldRegister(_)
-            | Self::DefRangeRegisterRelative(_) => None,
+            | Self::DefRangeRegisterRelative(_)
+            | Self::FrameProcedure(_) => None,
         }
     }
 }
@@ -376,6 +382,10 @@ impl<'t> TryFromCtx<'t> for SymbolData<'t> {
                 SymbolData::DefRangeSubFieldRegister(buf.parse_with(kind)?)
             }
             S_DEFRANGE_REGISTER_REL => SymbolData::DefRangeRegisterRelative(buf.parse_with(kind)?),
+            S_BPREL32 | S_BPREL32_ST | S_BPREL32_16t => {
+                SymbolData::BasePointerRelative(buf.parse_with(kind)?)
+            }
+            S_FRAMEPROC => SymbolData::FrameProcedure(buf.parse_with(kind)?),
             other => return Err(Error::UnimplementedSymbolKind(other)),
         };
 
@@ -2211,6 +2221,164 @@ impl<'t> TryFromCtx<'t, SymbolKind> for CoffGroupSymbol<'t> {
             characteristics: buf.parse()?,
             offset: buf.parse()?,
             name: parse_symbol_name(&mut buf, kind)?,
+        };
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L3573
+/// BP-Relative variable
+///
+/// Symbol type `S_BPREL32`, `S_BPREL32_ST`, `S_BPREL16`, `S_BPREL32_16t`
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BasePointerRelativeSymbol<'t> {
+    /// BP-relative offset
+    pub offset: u32,
+    /// Type index or Metadata token
+    pub type_index: TypeIndex,
+    /// Length-prefixed name
+    pub name: RawString<'t>,
+}
+
+impl<'t> TryFromCtx<'t, SymbolKind> for BasePointerRelativeSymbol<'t> {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'t [u8], kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        let symbol = match kind {
+            S_BPREL32 | S_BPREL32_ST => Self {
+                offset: buf.parse()?,
+                type_index: buf.parse()?,
+                name: parse_symbol_name(&mut buf, kind)?,
+            },
+            S_BPREL32_16t => Self {
+                offset: buf.parse()?,
+                type_index: TypeIndex::from(buf.parse::<u16>()? as u32),
+                name: parse_symbol_name(&mut buf, kind)?,
+            },
+            _ => return Err(Error::UnimplementedSymbolKind(kind)),
+        };
+
+        Ok((symbol, buf.pos()))
+    }
+}
+
+/// Frame procedure flags declared in `FrameProcedureSymbol`
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FrameProcedureFlags {
+    /// function uses `_alloca()`
+    has_alloca: bool,
+    /// function uses `setjmp()`
+    has_setjmp: bool,
+    /// function uses `longjmp()`
+    has_longjmp: bool,
+    /// function uses inline asm
+    has_inline_asm: bool,
+    /// function has EH states
+    has_eh: bool,
+    /// function was speced as inline
+    inline_spec: bool,
+    /// function has `SEH`
+    has_seh: bool,
+    /// function is `__declspec(naked)`
+    naked: bool,
+    /// function has buffer security check introduced by `/GS`.
+    security_checks: bool,
+    /// function compiled with `/EHa`
+    async_eh: bool,
+    /// function has `/GS` buffer checks, but stack ordering couldn't be done
+    gs_no_stack_ordering: bool,
+    /// function was inlined within another function
+    was_inlined: bool,
+    /// function is `__declspec(strict_gs_check)`
+    gs_check: bool,
+    /// function is `__declspec(safebuffers)`
+    safe_buffers: bool,
+    /// record function's local pointer explicitly.
+    encoded_local_base_pointer: u8,
+    /// record function's parameter pointer explicitly.
+    encoded_param_base_pointer: u8,
+    /// function was compiled with `PGO/PGU`
+    pogo_on: bool,
+    /// Do we have valid Pogo counts?
+    valid_counts: bool,
+    /// Did we optimize for speed?
+    opt_speed: bool,
+    /// function contains CFG checks (and no write checks)
+    guard_cf: bool,
+    /// function contains CFW checks and/or instrumentation
+    guard_cfw: bool,
+}
+
+impl<'t> TryFromCtx<'t, Endian> for FrameProcedureFlags {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'t [u8], le: Endian) -> Result<(Self, usize)> {
+        let raw = this.pread_with::<u32>(0, le)?;
+        let flags = Self {
+            has_alloca: raw & 1 != 0,
+            has_setjmp: (raw >> 1) & 1 != 0,
+            has_longjmp: (raw >> 2) & 1 != 0,
+            has_inline_asm: (raw >> 3) & 1 != 0,
+            has_eh: (raw >> 4) & 1 != 0,
+            inline_spec: (raw >> 5) & 1 != 0,
+            has_seh: (raw >> 6) & 1 != 0,
+            naked: (raw >> 7) & 1 != 0,
+            security_checks: (raw >> 8) & 1 != 0,
+            async_eh: (raw >> 9) & 1 != 0,
+            gs_no_stack_ordering: (raw >> 10) & 1 != 0,
+            was_inlined: (raw >> 11) & 1 != 0,
+            gs_check: (raw >> 12) & 1 != 0,
+            safe_buffers: (raw >> 13) & 1 != 0,
+            encoded_local_base_pointer: (raw >> 14) as u8 & 3,
+            encoded_param_base_pointer: (raw >> 16) as u8 & 3,
+            pogo_on: (raw >> 18) & 1 != 0,
+            valid_counts: (raw >> 19) & 1 != 0,
+            opt_speed: (raw >> 20) & 1 != 0,
+            guard_cf: (raw >> 21) & 1 != 0,
+            guard_cfw: (raw >> 22) & 1 != 0,
+        };
+
+        Ok((flags, 4))
+    }
+}
+
+// https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L4069
+/// Extra frame and proc information
+///
+/// Symbol type `S_FRAMEPROC`
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FrameProcedureSymbol {
+    /// count of bytes of total frame of procedure
+    pub frame_byte_count: u32,
+    /// count of bytes of padding in the frame
+    pub padding_byte_count: u32,
+    /// offset (relative to frame pointer) to where padding starts
+    pub offset_padding: u32,
+    /// count of bytes of callee save registers
+    pub callee_save_registers_byte_count: u32,
+    /// offset of exception handler
+    pub exception_handler_offset: PdbInternalSectionOffset,
+    /// flags
+    pub flags: FrameProcedureFlags,
+}
+
+impl TryFromCtx<'_, SymbolKind> for FrameProcedureSymbol {
+    type Error = Error;
+
+    fn try_from_ctx(this: &'_ [u8], _kind: SymbolKind) -> Result<(Self, usize)> {
+        let mut buf = ParseBuffer::from(this);
+
+        let symbol = FrameProcedureSymbol {
+            frame_byte_count: buf.parse()?,
+            padding_byte_count: buf.parse()?,
+            offset_padding: buf.parse()?,
+            callee_save_registers_byte_count: buf.parse()?,
+            exception_handler_offset: buf.parse()?,
+            flags: buf.parse_with(LE)?,
         };
 
         Ok((symbol, buf.pos()))

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -382,7 +382,7 @@ impl<'t> TryFromCtx<'t> for SymbolData<'t> {
                 SymbolData::DefRangeSubFieldRegister(buf.parse_with(kind)?)
             }
             S_DEFRANGE_REGISTER_REL => SymbolData::DefRangeRegisterRelative(buf.parse_with(kind)?),
-            S_BPREL32 | S_BPREL32_ST | S_BPREL32_16t => {
+            S_BPREL32 | S_BPREL32_ST | S_BPREL32_16T => {
                 SymbolData::BasePointerRelative(buf.parse_with(kind)?)
             }
             S_FRAMEPROC => SymbolData::FrameProcedure(buf.parse_with(kind)?),
@@ -2230,7 +2230,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for CoffGroupSymbol<'t> {
 // https://github.com/Microsoft/microsoft-pdb/blob/082c5290e5aff028ae84e43affa8be717aa7af73/include/cvinfo.h#L3573
 /// BP-Relative variable
 ///
-/// Symbol type `S_BPREL32`, `S_BPREL32_ST`, `S_BPREL16`, `S_BPREL32_16t`
+/// Symbol type `S_BPREL32`, `S_BPREL32_ST`, `S_BPREL16`, `S_BPREL32_16T`
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BasePointerRelativeSymbol<'t> {
     /// BP-relative offset
@@ -2253,7 +2253,7 @@ impl<'t> TryFromCtx<'t, SymbolKind> for BasePointerRelativeSymbol<'t> {
                 type_index: buf.parse()?,
                 name: parse_symbol_name(&mut buf, kind)?,
             },
-            S_BPREL32_16t => Self {
+            S_BPREL32_16T => Self {
                 offset: buf.parse()?,
                 type_index: TypeIndex::from(buf.parse::<u16>()? as u32),
                 name: parse_symbol_name(&mut buf, kind)?,


### PR DESCRIPTION
@CouleeApps implemented the symbols S_FRAMEPROC and S_BPREL32 (with variants).

I added a commit to rename all _16t constants to _16T, since the newly added uses of S_BPREL32_16t in match statements triggered two new warnings.
