### PR TITLE
fix: compilation error in tests

### DIFF
--- a/tests/pdb_information.rs
+++ b/tests/pdb_information.rs
@@ -1,4 +1,5 @@
 use pdb2 as pdb;
+use uuid::Uuid;
 
 #[test]
 fn pdb_info() {
@@ -10,7 +11,9 @@ fn pdb_info() {
     assert_eq!(pdb_info.age, 2);
     assert_eq!(
         pdb_info.guid,
-        "2B3C3FA5-5A2E-44B8-8BBA-C3300FF69F62".parse().unwrap(),
+        "2B3C3FA5-5A2E-44B8-8BBA-C3300FF69F62"
+            .parse::<Uuid>()
+            .unwrap(),
     );
     assert_eq!(pdb_info.signature, 0x587B_A621);
 }


### PR DESCRIPTION
Maybe caused by a different Rust edition? Well, it shouldn't hurt like this.